### PR TITLE
Added autoconf/automake support for SDL

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,197 @@
+
+AM_LDFLAGS=
+AM_CFLAGS=
+
+DEFS+= \
+    -Icsrc -Icppsrc -Idogmsrc -Inonarduino \
+    `getconf LFS_CFLAGS` \
+    `getconf LFS64_CFLAGS` \
+    -D_GNU_SOURCE \
+    -D_FILE_OFFSET_BITS=64 \
+    $(NULL)
+
+AM_CFLAGS+= \
+    -I$(top_builddir)/include/ \
+    $(NULL)
+
+AM_LDFLAGS += \
+    -L$(top_builddir)/ \
+    `getconf LFS_LDFLAGS` \
+    `getconf LFS64_LDFLAGS` \
+    $(NULL)
+
+if DEBUG
+# use "valgrind --tool=memcheck --leak-check=yes" to check memory leak, MemWatch will drag the program.
+#DEFS+=-DMEMWATCH
+DEFS+= -DDEBUG=1
+AM_CFLAGS+=-g -Wall
+
+else
+AM_CFLAGS+=-O3 -Wall
+endif
+
+EXT_FLAGS=
+@MK@GITNUMTMP=$(shell cd "$(top_srcdir)"; A=$$(git show | head -n 1 | awk '{print $$2}'); echo $${A:0:7}; cd - > /dev/null )
+#@MK@SVNNUMTMP=$(shell cd "$(top_srcdir)"; LC_ALL=C svn info | grep -i Revision | awk '{print $$2}'; cd - > /dev/null )
+#@MK@ifeq ($(SVNNUMTMP),)
+#EXT_FLAGS+= -DSVN_VERSION='"${GITNUMTMP}"'
+#@MK@else
+#EXT_FLAGS+= -DSVN_VERSION='"${SVNNUMTMP}"'
+#@MK@endif
+@MK@ifeq ($(GITNUMTMP),)
+@MK@else
+EXT_FLAGS+= -DSVN_VERSION='"${GITNUMTMP}"'
+@MK@endif
+DEFS+=$(EXT_FLAGS)
+
+SRC_BASE= \
+    csrc/ucg_line.c \
+    csrc/ucg_dev_default_cb.c \
+    csrc/ucg_dev_ic_ili9163.c \
+    csrc/ucg_bitmap.c \
+    csrc/ucg_circle.c \
+    csrc/ucg_dev_tft_240x320_ili9341.c \
+    csrc/ucg_dev_ic_ili9341.c \
+    csrc/ucg_scale.c \
+    csrc/ucg_dev_tft_128x160_st7735.c \
+    csrc/ucg_clip.c \
+    csrc/ucg_dev_msg_api.c \
+    csrc/ucg_init.c \
+    csrc/ucg_font.c \
+    csrc/ucg_polygon.c \
+    csrc/ucg_dev_oled_128x128_ilsoft.c \
+    csrc/ucg_ccs.c \
+    csrc/ucg_rotate.c \
+    csrc/ucg_dev_oled_160x128_samsung.c \
+    csrc/ucg_vector_font_data.c \
+    csrc/ucg_dev_tft_240x320_ssd1289.c \
+    csrc/ucg_dev_ic_pcf8833.c \
+    csrc/ucg_dev_oled_128x128_ft.c \
+    csrc/ucg_dev_tft_240x320_ili9325_spi.c \
+    csrc/ucg_box.c \
+    csrc/ucg_dev_ic_ld50t6160.c \
+    csrc/ucg_pixel.c \
+    csrc/ucg_dev_ic_ssd1351.c \
+    csrc/ucg_dev_tft_240x320_itdb02.c \
+    csrc/ucg_dev_ic_ssd1289.c \
+    csrc/ucg_dev_ic_st7735.c \
+    csrc/ucg_dev_tft_132x132_pcf8833.c \
+    csrc/ucg_com_msg_api.c \
+    csrc/ucg_dev_ic_ili9325_spi.c \
+    csrc/ucg.h \
+    csrc/ucg_dev_tft_128x128_ili9163.c \
+    csrc/ucg_pixel_font_data.c \
+    csrc/ucg_dev_ic_ili9325.c \
+    $(NULL)
+
+SRC_COMMON= \
+    $(NULL)
+
+SRC_WPI= \
+    $(SRC_COMMON) \
+    cppsrc/Ucglib.cpp \
+    $(NULL)
+
+SRC_SDL= \
+    $(SRC_COMMON) \
+    sys/sdl/dev/ucg_dev_sdl.c \
+    $(NULL)
+
+include_HEADERS = \
+    $(top_srcdir)/csrc/ucg.h \
+    $(top_srcdir)/cppsrc/Ucglib.h \
+    $(top_srcdir)/nonarduino/Printable.h \
+    $(top_srcdir)/nonarduino/Print.h \
+    $(top_srcdir)/nonarduino/WString.h \
+    $(NULL)
+
+noinst_HEADERS=
+
+lib_LTLIBRARIES=libucgbase.la libucgsdl.la #libucgwpi.la
+
+libucgbase_la_SOURCES=$(SRC_BASE)
+
+libucgsdl_la_SOURCES=$(SRC_SDL)
+
+libucgwpi_la_SOURCES=$(SRC_WPI)
+
+libucgbase_la_CFLAGS=-Icsrc -Icppsrc -Inonarduino -DUCG_16BIT `sdl-config --cflags`
+libucgbase_la_CPPFLAGS=$(libucgbase_la_CFLAGS)
+libucgbase_la_LDFLAGS=
+
+libucgsdl_la_CFLAGS=-Icsrc -Icppsrc -Inonarduino -DUCG_16BIT `sdl-config --cflags`
+libucgsdl_la_CPPFLAGS=$(libucgsdl_la_CFLAGS)
+libucgsdl_la_LDFLAGS=`sdl-config --libs`
+libucgsdl_la_LIBADD=$(top_builddir)/libucgbase.la
+
+libucgwpi_la_CFLAGS=-Icsrc -Icppsrc -Inonarduino -DUCG_16BIT -DUCG_WITH_PINLIST -DUCG_RASPBERRY_PI
+libucgwpi_la_CPPFLAGS=$(libucgwpi_la_CFLAGS)
+libucgwpi_la_LDFLAGS=-lwiringPi
+libucgwpi_la_LIBADD=$(top_builddir)/libucgbase.la
+
+
+BIN_SDL=ucgsdl_showtga ucgsdl_testdisk ucgsdl_testfont ucgsdl_testfontr ucgsdl_testrotate ucgsdl_testscale ucgsdl_logo
+
+BIN_WPI=ucgwpi_testfont ucgwpi_gtest ucgwpi_logo
+
+BIN_TOOLS=bdf2ucg
+bdf2ucg_SOURCES= \
+    tools/font/bdf2ucg/bdf2ucg.c \
+    $(NULL)
+test:
+	./bdf2ucg -f 2 tools/font/bdf/9x18.bdf ucg_aafont_9x18 test_ucg_aafont_9x18.c
+
+bin_PROGRAMS=$(BIN_TOOLS) $(BIN_SDL)
+#noinst_PROGRAMS=$(BIN_WPI)
+
+ucgsdl_showtga_SOURCES=sys/sdl/show_tga/main.c
+ucgsdl_showtga_CPPFLAGS=$(libucgsdl_la_CFLAGS)
+ucgsdl_showtga_LDFLAGS=-lucgbase -lucgsdl $(libucgsdl_la_LDFLAGS)
+
+ucgsdl_testdisk_SOURCES=sys/sdl/test_disk/main.c
+ucgsdl_testdisk_CPPFLAGS=$(libucgsdl_la_CFLAGS)
+ucgsdl_testdisk_LDFLAGS=-lucgbase -lucgsdl $(libucgsdl_la_LDFLAGS)
+
+ucgsdl_testfont_SOURCES=sys/sdl/test_font/main.c
+ucgsdl_testfont_CPPFLAGS=$(libucgsdl_la_CFLAGS)
+ucgsdl_testfont_LDFLAGS=-lucgbase -lucgsdl $(libucgsdl_la_LDFLAGS)
+
+ucgsdl_testfontr_SOURCES=sys/sdl/test_font_rotate/main.c
+ucgsdl_testfontr_CPPFLAGS=$(libucgsdl_la_CFLAGS)
+ucgsdl_testfontr_LDFLAGS=-lucgbase -lucgsdl $(libucgsdl_la_LDFLAGS)
+
+ucgsdl_testrotate_SOURCES=sys/sdl/test_rotate/main.c
+ucgsdl_testrotate_CPPFLAGS=$(libucgsdl_la_CFLAGS)
+ucgsdl_testrotate_LDFLAGS=-lucgbase -lucgsdl $(libucgsdl_la_LDFLAGS)
+
+ucgsdl_testscale_SOURCES=sys/sdl/test_scale/main.c
+ucgsdl_testscale_CPPFLAGS=$(libucgsdl_la_CFLAGS)
+ucgsdl_testscale_LDFLAGS=-lucgbase -lucgsdl $(libucgsdl_la_LDFLAGS)
+
+#ucgsdl_logo_SOURCES=sys/sdl/cpp_logo/main.cpp
+#ucgsdl_logo_CPPFLAGS=$(libucgsdl_la_CFLAGS)
+#ucgsdl_logo_LDFLAGS=-lucgbase -lucgsdl $(libucgsdl_la_LDFLAGS)
+
+ucgsdl_logo_SOURCES=sys/sdl/ucglib_logo/main.c
+ucgsdl_logo_CPPFLAGS=$(libucgsdl_la_CFLAGS)
+ucgsdl_logo_LDFLAGS=-lucgbase -lucgsdl $(libucgsdl_la_LDFLAGS)
+
+.pde.cpp:
+	cp $< $@
+.ino.o:
+	cp $< $@
+
+#ucgwpi_logo_SOURCES=sys/arm/examples/u8g_logo/u8g_logo.c
+#ucgwpi_logo_SOURCES=sys/atmega/u8g_logo/u8g_logo.c
+ucgwpi_logo_SOURCES=nonarduino/wpimain.cpp sys/arduino/UcgLogo/UcgLogo.ino
+ucgwpi_logo_CFLAGS=$(libucgwpi_la_CFLAGS)
+ucgwpi_logo_CPPFLAGS=$(libucgwpi_la_CFLAGS)
+ucgwpi_logo_LDFLAGS=-lucgbase -lucgwpi $(libucgwpi_la_LDFLAGS)
+
+ucgwpi_gtest_SOURCES=nonarduino/wpimain.cpp sys/arduino/GraphicsTest/GraphicsTest.ino
+ucgwpi_gtest_CPPFLAGS=$(libucgwpi_la_CFLAGS)
+ucgwpi_gtest_LDFLAGS=-lucgbase -lucgwpi $(libucgwpi_la_LDFLAGS)
+
+ucgwpi_testfont_SOURCES=nonarduino/wpimain.cpp sys/arduino/HowToUseFonts/HowToUseFonts.ino
+ucgwpi_testfont_CPPFLAGS=$(libucgwpi_la_CFLAGS)
+ucgwpi_testfont_LDFLAGS=-lucgbase -lucgwpi $(libucgwpi_la_LDFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -97,7 +97,7 @@ SRC_SDL= \
     sys/sdl/dev/ucg_dev_sdl.c \
     $(NULL)
 
-include_HEADERS = \
+#include_HEADERS = \
     $(top_srcdir)/csrc/ucg.h \
     $(top_srcdir)/cppsrc/Ucglib.h \
     $(top_srcdir)/nonarduino/Printable.h \

--- a/autoclean.sh
+++ b/autoclean.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+chmod 755 $0 autogen.sh config.guess config.rpath config.status config.sub configure depcomp install-sh missing
+
+make clean
+make distclean
+
+rm -f *.o
+
+rm -f config.log
+rm -f config.status
+rm -f config.h
+rm -f Makefile
+rm -rf ./autom4te.cache/
+rm -f gmon.out
+
+#rm -f ./src/Makefile.in
+#rm -f ./Makefile.in

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+PROGNAME="$0"
+#DN_EXEC=`echo "${PROGNAME}" | ${EXEC_AWK} -F/ '{b=$1; for (i=2; i < NF; i ++) {b=b "/" $(i)}; print b}'`
+DN_EXEC=`dirname "${PROGNAME}"`
+if [ ! "${DN_EXEC}" = "" ]; then
+    DN_EXEC="${DN_EXEC}/"
+else
+    DN_EXEC="./"
+fi
+
+${DN_EXEC}autoclean.sh
+
+rm -f configure
+
+rm -f Makefile.in
+
+rm -f config.guess
+rm -f config.sub
+rm -f install-sh
+rm -f missing
+rm -f depcomp
+
+# install libs
+#which apt-get
+#if [ "$?" = "0" ]; then
+    #sudo apt-get install -y libxml2-dev libxslt-dev libicu-dev
+    ## for traceback
+    #sudo apt-get install -y binutils-dev libiberty-dev
+    ## for doxygen
+    #sudo apt-get install -y graphviz doxygen texlive-full
+#fi
+
+#which yum
+#if [ "$?" = "0" ]; then
+    #sudo yum install -y libxml2-devel libxslt-devel libicu-devel
+#if
+
+if [ 0 = 1 ]; then
+autoscan
+else
+#cd pflib && ${DN_EXEC}autogen.sh && cd ..
+
+touch NEWS
+touch README
+touch AUTHORS
+touch ChangeLog
+touch config.h.in
+
+libtoolize --force --copy --install --automake
+aclocal
+#automake -ac
+automake --copy --add-missing --gnu
+autoconf
+
+autoreconf # run twice to get rid of 'ltmain.sh not found'
+autoreconf
+
+if [ 1 = 1 ]; then
+rm -rf build
+mkdir -p build
+cd build
+fi
+
+#${DN_EXEC}configure --enable-debug
+#./configure --enable-debug
+#make clean
+#make
+
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,77 @@
+#                                               -*- Autoconf -*-
+# Process this file with autoconf to produce a configure script.
+
+AC_PREREQ([2.69])
+AC_INIT(ucglib, 1.0, [BUG-REPORT-ADDRESS])
+AC_CONFIG_SRCDIR([csrc/ucg_font.c])
+AC_CONFIG_HEADERS([config.h])
+AM_INIT_AUTOMAKE(-Wall subdir-objects)
+
+#magic for conditional check in Makefile:
+MK=''; AC_SUBST(MK)
+SED=sed
+
+# Checks for programs.
+AC_PROG_AWK
+AC_PROG_CXX
+AC_PROG_CC
+AM_PROG_CC_C_O
+AC_PROG_CPP
+AM_PROG_AR
+AC_PROG_LIBTOOL
+
+# Checks for libraries.
+LT_PREREQ([2.2])
+#LT_INIT([shared static])
+LT_INIT([disable-static])
+
+# debug
+AC_ARG_ENABLE([debug],
+	AS_HELP_STRING([--enable-debug],[Compile the debug version (default: disabled)]),
+	[enable_debug=$enableval],
+	[enable_debug=no])
+AM_CONDITIONAL([DEBUG], [test $enable_debug = "yes"])
+if test "x$enable_debug" = "xyes"; then
+  changequote({,})
+  CFLAGS=`echo "$CFLAGS" | $SED -e 's/-O[0-9s]*//g'`
+  CXXFLAGS=`echo "$CXXFLAGS" | $SED -e 's/-O[0-9s]*//g'`
+  changequote([,])
+  dnl add -O0 only if GCC or ICC is used
+  if test "$GCC" = "yes" || test "$ICC" = "yes"; then
+    CFLAGS="$CFLAGS -g -O0 -Wall"
+    CXXFLAGS="$CXXFLAGS -g -O0 -Wall"
+  fi
+else
+  changequote({,})
+  CFLAGS=`echo "$CFLAGS" | $SED -e 's/-g//g'`
+  CXXFLAGS=`echo "$CXXFLAGS" | $SED -e 's/-g//g'`
+  changequote([,])
+fi
+
+# Checks for libraries.
+# FIXME: Replace `main' with a function in `-lwiringPi':
+AC_CHECK_LIB([wiringPi], [main])
+
+# Checks for header files.
+AC_CHECK_HEADERS([float.h stddef.h stdint.h stdlib.h string.h])
+
+# Checks for typedefs, structures, and compiler characteristics.
+AC_CHECK_HEADER_STDBOOL
+AC_C_INLINE
+AC_TYPE_INT16_T
+AC_TYPE_INT32_T
+AC_TYPE_INT64_T
+AC_TYPE_INT8_T
+AC_TYPE_SIZE_T
+AC_TYPE_UINT16_T
+AC_TYPE_UINT32_T
+AC_TYPE_UINT64_T
+AC_TYPE_UINT8_T
+
+# Checks for library functions.
+AC_CHECK_FUNCS([atexit memset sqrt strerror])
+
+AC_CONFIG_FILES([Makefile
+                 ])
+#AC_CONFIG_SUBDIRS([tools/font/otf2bdf])
+AC_OUTPUT

--- a/sys/sdl/test_disk/main.c
+++ b/sys/sdl/test_disk/main.c
@@ -1,9 +1,8 @@
 
-
-#include "ucg.h"
 #include <stdlib.h>
 #include <stdio.h>
 
+#include "ucg.h"
 
 int ucg_sdl_get_key(void);
 
@@ -17,7 +16,7 @@ int main(void)
 {
   
   ucg_Init(&ucg, &ucg_sdl_dev_cb, ucg_ext_none, (ucg_com_fnptr)0);
-  ucg_SetFont(&ucg, ucg_font_ncenB12);  
+  ucg_SetFont(&ucg, ucg_font_9x15_67_75);
   ucg_SetColor(&ucg, 0, 255, 180, 40);
   
   ucg_DrawGlyph(&ucg, 20,20, 0, 'A');

--- a/sys/sdl/test_rotate/main.c
+++ b/sys/sdl/test_rotate/main.c
@@ -18,7 +18,7 @@ int main(void)
   
   ucg_Init(&ucg, &ucg_sdl_dev_cb, ucg_ext_none, (ucg_com_fnptr)0);
   ucg_SetFontMode(&ucg, UCG_FONT_MODE_TRANSPARENT);
-  ucg_SetFont(&ucg, ucg_font_ncenB24);  
+  ucg_SetFont(&ucg, ucg_font_9x15_67_75);
   ucg_SetRotate90(&ucg);
 
   ucg_SetColor(&ucg, 0, 255, 180, 40);

--- a/sys/sdl/test_scale/main.c
+++ b/sys/sdl/test_scale/main.c
@@ -18,7 +18,7 @@ int main(void)
   
   ucg_Init(&ucg, &ucg_sdl_dev_cb, ucg_ext_none, (ucg_com_fnptr)0);
   ucg_SetFontMode(&ucg, UCG_FONT_MODE_TRANSPARENT);
-  ucg_SetFont(&ucg, ucg_font_ncenB12);  
+  ucg_SetFont(&ucg, ucg_font_9x15_67_75);
   ucg_SetColor(&ucg, 0, 255, 180, 40);
   
   ucg_DrawGlyph(&ucg, 20,20, 0, 'A');

--- a/sys/sdl/ucglib_logo/main.c
+++ b/sys/sdl/ucglib_logo/main.c
@@ -87,7 +87,7 @@ int main(void)
   
   ucg_Init(&ucg, ucg_sdl_dev_cb, ucg_ext_none, (ucg_com_fnptr)0);
   ucg_SetFontMode(&ucg, UCG_FONT_MODE_TRANSPARENT);
-  ucg_SetFont(&ucg, ucg_font_ncenB24);  
+  ucg_SetFont(&ucg, ucg_font_9x15_67_75);
   //ucg_SetRotate90(&ucg);
   
   //ucg_SetRotate270(&ucg);  
@@ -156,7 +156,7 @@ int main(void)
   ucg_DrawGradientBox(&ucg, 84, 42-6, 42, 4);
 
   ucg_SetColor(&ucg, 0, 255, 168, 0);
-  ucg_SetFont(&ucg, ucg_font_5x8);
+  ucg_SetFont(&ucg, ucg_font_5x8_8f);
   //ucg_SetFont(&ucg, ucg_font_courB08);
   ucg_DrawString(&ucg, 2, 54, 0, "http://");
   ucg_DrawString(&ucg, 1, 61, 0, "code.google.com/p/ucglib/");


### PR DESCRIPTION
I here add this support so we can compile and debug in a linux machine instead of waiting long time to download and run in hardware.

Would you please consider to support Raspberry Pi via wiringPi, just as you did in u8glib?
I also have a similar patch for u8glib, and I can't open a pull request since you didn't us github and google code is downing. You can access it by https://github.com/yhfudev/u8glib.git

And I also have a multi-language patch, which supports use UTF-8 string in source file instead of converting the code map by programmer, thus relieve the pain in previous version. Can you please to consider to integrate it to the next version of u8glib? https://github.com/yhfudev/u8glib-fontutf8.git

