### PR TITLE
Usage on esp-idf platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Version v1.01 for Arduino IDE 1.0.x [![](https://api.bintray.com/packages/olikra
 
 Clone in your components directory using the following command.
 
-`git submodules add https://github.com/olikraus/ucglib components/u8g2`
+`git submodule add https://github.com/olikraus/ucglib components/u8g2`
 
 
 # Screenshot

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Supported display controller: ST7735, ILI9341, PCF8833, SSD1351, LD50T6160, ILI9
 
 Features: Graphics primitives with 18 bit color depth, filled polygon draw, >300, landscape/portrait mode.
 
+# Arduino
 See the [github wiki](https://github.com/olikraus/ucglib/wiki) for reference manual and tutorials.
-
 
 [//]: # ([Download Ucglib Arduino Library](https://github.com/olikraus/Ucglib_Arduino/releases/latest))
 
@@ -15,4 +15,13 @@ See the [github wiki](https://github.com/olikraus/ucglib/wiki) for reference man
 
 Version v1.01 for Arduino IDE 1.0.x [![](https://api.bintray.com/packages/olikraus/Ucglib/Arduino/images/download.png)](https://bintray.com/olikraus/Ucglib/Arduino/_latestVersion)
 
+# ESP-IDF
+
+Clone in your components directory using the following command.
+
+`git submodules add https://github.com/olikraus/ucglib components/u8g2`
+
+
+# Screenshot
 <a href='http://www.youtube.com/watch?feature=player_embedded&v=GSpYY0AMtEU' target='_blank'><img src='http://img.youtube.com/vi/GSpYY0AMtEU/0.jpg' width='425' height=344 /></a>
+

--- a/component.mk
+++ b/component.mk
@@ -1,0 +1,11 @@
+#
+# Main Makefile. This is basically the same as a component makefile.
+#
+# This Makefile should, at the very least, just include $(SDK_PATH)/make/component_common.mk. By default, 
+# this will take the sources in the src/ directory, compile them and link them into 
+# lib(subdirectory_name).a in the build directory. This behaviour is entirely configurable,
+# please read the ESP-IDF documents if you need to do this.
+#
+
+COMPONENT_SRCDIRS:=csrc
+COMPONENT_ADD_INCLUDEDIRS:=csrc


### PR DESCRIPTION
# Problem
Solve issue https://github.com/olikraus/ucglib/issues/111

# Solution proposed 
The library can be used on ESP32 devices using the ESP-IDF platform, in order to do it it's needed to add the component.mk file like proposed in this pull request.

## external documentation
The ESP-IDF platform documentation is available [here](https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html).

Let me know if something is not clear.