### PR TITLE
Implement frame buffer

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -71,6 +71,7 @@ SRC_BASE= \
     csrc/ucg_box.c \
     csrc/ucg_dev_ic_ld50t6160.c \
     csrc/ucg_pixel.c \
+    csrc/ucg_dev_buffer.c \
     csrc/ucg_dev_ic_ssd1351.c \
     csrc/ucg_dev_tft_240x320_itdb02.c \
     csrc/ucg_dev_ic_ssd1289.c \

--- a/csrc/ucg.h
+++ b/csrc/ucg.h
@@ -170,7 +170,7 @@ ucg_int_t ucg_dev_pcf8833_16x132x132(ucg_t *ucg, ucg_int_t msg, void *data);
 ucg_int_t ucg_dev_ld50t6160_18x160x128_samsung(ucg_t *ucg, ucg_int_t msg, void *data);
 ucg_int_t ucg_dev_ssd1331_18x96x64_univision(ucg_t *ucg, ucg_int_t msg, void *data);
 ucg_int_t ucg_dev_seps225_16x128x128_univision(ucg_t *ucg, ucg_int_t msg, void *data);
-
+ucg_int_t ucg_dev_st7789_16x240x240(ucg_t *ucg, ucg_int_t msg, void *data);
 
 
 /*================================================*/

--- a/csrc/ucg.h
+++ b/csrc/ucg.h
@@ -363,6 +363,23 @@ typedef struct _ucg_font_decode_t ucg_font_decode_t;
 #define UCG_PIN_VAL_NONE 255
 #endif
 
+typedef void (*ucg_com_send_byte)(uint8_t data); 
+
+struct _ucg_com_cb_funcs {
+  void (*power_up)(ucg_t *, ucg_com_info_t *);
+  void (*power_down)(ucg_t *);
+  void (*delay)(ucg_t *, uint16_t);
+  void (*change_reset_line)(ucg_t *, uint8_t);
+  void (*change_cd_line)(ucg_t *, uint8_t);
+  void (*change_cs_line)(ucg_t *, uint8_t);
+  void (*send_byte)(ucg_t *, uint8_t);
+  void (*repeat_1_byte)(ucg_t *, uint16_t, uint8_t);
+  void (*repeat_2_bytes)(ucg_t *, uint16_t, uint8_t[2]);
+  void (*repeat_3_bytes)(ucg_t *, uint16_t, uint8_t[3]);
+  void (*send_str)(ucg_t *, uint16_t, uint8_t *);
+  void (*send_cd_data_sequence)(ucg_t *, uint16_t, uint8_t[]);
+};
+
 struct _ucg_t
 {
   unsigned is_power_up:1;
@@ -385,6 +402,8 @@ struct _ucg_t
   
   /* communication interface */
   ucg_com_fnptr com_cb;
+
+  struct _ucg_com_cb_funcs com_cb_funcs;
   
   /* offset, that is additionally added to UCG_VARX/UCG_VARY */
   /* seems to be required for the Nokia display */

--- a/csrc/ucg_com_msg_api.c
+++ b/csrc/ucg_com_msg_api.c
@@ -35,10 +35,9 @@
 
 #include "ucg.h"
 
-static int16_t ucg_com_template_cb(ucg_t *ucg, int16_t msg, uint32_t arg, uint8_t *data);
 static void ucg_com_SendStringP(ucg_t *ucg, uint16_t cnt, const ucg_pgm_uint8_t *byte_ptr);
 
-static __attribute__((unused)) int16_t ucg_com_template_cb(ucg_t *ucg, int16_t msg, uint32_t arg, uint8_t *data)
+int16_t ucg_com_none_cb(ucg_t *ucg, int16_t msg, uint16_t arg, uint8_t *data)
 {
   (void)ucg;
   (void)arg;
@@ -73,7 +72,6 @@ static __attribute__((unused)) int16_t ucg_com_template_cb(ucg_t *ucg, int16_t m
   }
   return 1;
 }
-
 
 void ucg_com_PowerDown(ucg_t *ucg)
 {

--- a/csrc/ucg_dev_buffer.c
+++ b/csrc/ucg_dev_buffer.c
@@ -1,0 +1,84 @@
+/*
+
+  ucg_dev_memory.c
+  
+  Memory buffer device.
+
+  Universal uC Color Graphics Library
+  
+  Copyright (c) 2015, olikraus@gmail.com
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification, 
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this list 
+    of conditions and the following disclaimer.
+    
+  * Redistributions in binary form must reproduce the above copyright notice, this 
+    list of conditions and the following disclaimer in the documentation and/or other 
+    materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+
+*/
+
+#include "ucg.h"
+
+ucg_int_t ucg_dev_buffer(ucg_t *ucg, ucg_int_t msg, void *data)
+{
+  ucg_wh_t dimension;
+  
+  switch(msg) {
+    case UCG_MSG_DEV_POWER_UP:
+      break;
+    case UCG_MSG_DEV_POWER_DOWN:
+      break;
+    case UCG_MSG_GET_DIMENSION:
+      break;
+    case UCG_MSG_DRAW_PIXEL:
+      if ( ucg_clip_is_pixel_visible(ucg) !=0 ) {
+        unsigned char *pixel;
+        ucg->device_cb_real(ucg, UCG_MSG_GET_DIMENSION, &dimension);
+
+        pixel = &(ucg->frame_buffer)[
+          (dimension.w * ucg->arg.pixel.pos.y * 3) + (ucg->arg.pixel.pos.x * 3)
+        ];
+        *pixel = ucg->arg.pixel.rgb.color[0];
+        *(pixel + 1) = ucg->arg.pixel.rgb.color[1];
+        *(pixel + 2) = ucg->arg.pixel.rgb.color[2];
+      }
+      return 1;
+    case UCG_MSG_SEND_BUFFER:
+      break;
+    case UCG_MSG_DRAW_L90FX:
+      ucg_handle_l90fx(ucg, ucg_dev_buffer);
+      return 1;
+    #ifdef UCG_MSG_DRAW_L90TC
+    case UCG_MSG_DRAW_L90TC:
+      ucg_handle_l90tc(ucg, ucg_dev_buffer);
+      return 1;
+    #endif
+    case UCG_MSG_DRAW_L90SE:
+      ucg_handle_l90se(ucg, ucg_dev_buffer);
+      return 1;
+    #ifdef UCG_MSG_DRAW_L90BF
+      case UCG_MSG_DRAW_L90BF:
+      ucg_handle_l90bf(ucg, ucg_dev_buffer);
+      return 1;
+    #endif
+  }
+  return ucg->device_cb_real(ucg, msg, data);
+}

--- a/csrc/ucg_dev_msg_api.c
+++ b/csrc/ucg_dev_msg_api.c
@@ -129,3 +129,18 @@ void ucg_DrawL90RLWithArg(ucg_t *ucg)
 }
 */
 
+void ucg_SendBuffer(ucg_t *ucg)
+{
+  ucg_dev_fnptr orig_device_cb;
+  ucg_wh_t dimension;
+
+  if(ucg->device_cb_real == NULL)
+    return;
+
+  ucg->device_cb_real(ucg, UCG_MSG_GET_DIMENSION, &dimension);
+
+  orig_device_cb = ucg->device_cb;
+  ucg->device_cb = ucg->device_cb_real;
+  ucg->device_cb(ucg, UCG_MSG_SEND_BUFFER, &dimension);
+  ucg->device_cb = orig_device_cb;
+}

--- a/csrc/ucg_dev_st7789.c
+++ b/csrc/ucg_dev_st7789.c
@@ -154,7 +154,7 @@ static void handle_l90fx(ucg_t *ucg) {
     case 0:
       dx = 1;
       dy = 0;
-      madctl_data = ST7789_MADCTL_COLUMN_ADDRESS_ORDER_RIGHT_TO_LEFT;
+      madctl_data = ST7789_MADCTL_COLUMN_ADDRESS_ORDER_LEFT_TO_RIGHT;
       break;
     case 1:
       dx = 0;
@@ -164,7 +164,7 @@ static void handle_l90fx(ucg_t *ucg) {
     case 2:
       dx = -1;
       dy = 0;
-      madctl_data = ST7789_MADCTL_COLUMN_ADDRESS_ORDER_LEFT_TO_RIGHT;
+      madctl_data = ST7789_MADCTL_COLUMN_ADDRESS_ORDER_RIGHT_TO_LEFT;
       break;
     case 3:
       dx = 0;

--- a/csrc/ucg_dev_st7789.c
+++ b/csrc/ucg_dev_st7789.c
@@ -15,7 +15,6 @@
 #define ST7789_COLMOD_COLOR_18BIT (1<<2|1<<1)  // 0x06
 #define ST7789_COLMOD_COLOR_READ (ST7789_COLMOD_RGB_262K|ST7789_COLMOD_COLOR_18BIT)
 #define ST7789_COLMOD_COLOR_16M (1<<2|1<<1|1)  // 0x07
-#define ST7789_MADCTL 0x36
 #define ST7789_CASET 0x2A
 #define ST7789_RASET 0x2B
 #define ST7789_INVOFF 0x20
@@ -24,6 +23,18 @@
 #define ST7789_NORON 0x13
 #define ST7789_RAMWR 0x2C
 #define ST7789_MADCTL 0x36
+#define ST7789_MADCTL_PAGE_ADDRESS_ORDER_TOP_TO_BOTTOM 0
+#define ST7789_MADCTL_PAGE_ADDRESS_ORDER_BOTTOM_TO_TOP (1<<7)
+#define ST7789_MADCTL_COLUMN_ADDRESS_ORDER_LEFT_TO_RIGHT 0
+#define ST7789_MADCTL_COLUMN_ADDRESS_ORDER_RIGHT_TO_LEFT (1<<6)
+#define ST7789_MADCTL_PAGE_COLUMN_ORDER_NORMAL 0
+#define ST7789_MADCTL_PAGE_COLUMN_ORDER_REVERSE (1<<5)
+#define ST7789_MADCTL_LINE_ADDRESS_ORDER_LCD_REFRESH_TOP_TO_BOTTOM 0
+#define ST7789_MADCTL_LINE_ADDRESS_ORDER_LCD_REFRESH_BOTTOM_TO_TOP (1<<4)
+#define ST7789_MADCTL_ORDER_RGB 0
+#define ST7789_MADCTL_ORDER_BGR (1<<3)
+#define ST7789_MADCTL_DISPLAY_DATA_LATCH_ORDER_LCD_REFRESH_LEFT_TO_RIGHT 0
+#define ST7789_MADCTL_DISPLAY_DATA_LATCH_ORDER_LCD_REFRESH_RIGHT_TO_LEFT 1
 
 #define ST7789_RESX_TRW_MS 10 // Reset pulse duration 
 #define ST7789_RESX_TRT_MS 120 // Reset cancel
@@ -39,7 +50,6 @@ static const ucg_pgm_uint8_t ucg_st7789_16x240x240_init_seq[] = {
   UCG_RST(1),
   UCG_DLY_MS(ST7789_RESX_TRT_MS),
 
-
   // Software reset
   UCG_CS(0),
   UCG_C10(ST7789_SWRESET),
@@ -54,6 +64,17 @@ static const ucg_pgm_uint8_t ucg_st7789_16x240x240_init_seq[] = {
 
   // Set color mode
   UCG_C11(ST7789_COLMOD, ST7789_COLMOD_COLOR_16BIT_WRITE),
+
+  // Memory Data Access Control
+  UCG_C11(
+    ST7789_MADCTL,
+    ST7789_MADCTL_PAGE_ADDRESS_ORDER_TOP_TO_BOTTOM |
+    ST7789_MADCTL_COLUMN_ADDRESS_ORDER_LEFT_TO_RIGHT |
+    ST7789_MADCTL_PAGE_COLUMN_ORDER_NORMAL |
+    ST7789_MADCTL_LINE_ADDRESS_ORDER_LCD_REFRESH_TOP_TO_BOTTOM |
+    ST7789_MADCTL_ORDER_RGB |
+    ST7789_MADCTL_DISPLAY_DATA_LATCH_ORDER_LCD_REFRESH_LEFT_TO_RIGHT
+  ),
 
   // Display inversion in practice works the opposite of what the datasheet
   // says: on is off and off is on.
@@ -77,14 +98,109 @@ static void send_cmd(ucg_t *ucg, uint8_t cmd) {
   ucg_com_SendString(ucg, 1, &cmd);
 }
 
-static void send_data(ucg_t *ucg, uint16_t count, uint8_t *data) {
+static void send_cmd_data(ucg_t *ucg, uint8_t cmd, uint16_t count, uint8_t *data) {
+  send_cmd(ucg, cmd);
   ucg_com_SetCDLineStatus(ucg, (ucg->com_cfg_cd)&1);
   ucg_com_SendString(ucg, count, data);
 }
 
-static void send_cmd_data(ucg_t *ucg, uint8_t cmd, uint16_t count, uint8_t *data) {
-  send_cmd(ucg, cmd);
-  send_data(ucg, count, data);
+static void set_column_address(ucg_t *ucg, uint16_t x_start, uint16_t x_end) {
+  uint8_t buff[4];
+
+  buff[0] = (x_start&0xFF00)>>8;
+  buff[1] = x_start&0xFF;
+  buff[2] = (x_end&0xFF00)>>8;
+  buff[3] = x_end&0xFF;
+
+  send_cmd_data(ucg, ST7789_CASET, 4, buff);
+}
+
+static void set_row_address(ucg_t *ucg, uint16_t y_start, uint16_t y_end) {
+  uint8_t buff[4];
+
+  buff[0] = (y_start&0xFF00)>>8;
+  buff[1] = y_start&0xFF;
+  buff[2] = (y_end&0xFF00)>>8;
+  buff[3] = y_end&0xFF;
+
+  send_cmd_data(ucg, ST7789_RASET, 4, buff);
+}
+
+static void set_16bit_color(ucg_t *ucg, uint8_t buff[2]) {
+  uint8_t r, g, b;
+
+  // 16 bit: RRRRRGGG GGGBBBBB
+  buff[0] = 0;
+  buff[1] = 0;
+  r = ucg->arg.pixel.rgb.color[0]>>(8-5);
+  buff[0] |= r << 3;
+  g = ucg->arg.pixel.rgb.color[1]>>(8-6);
+  buff[0] |= g>>3;
+  buff[1] |= g<<5;
+  b = ucg->arg.pixel.rgb.color[2]>>(8-5);
+  buff[1] |= b&0x1F;
+}
+
+#include <libopencm3/stm32/spi.h>
+
+static void handle_l90fx(ucg_t *ucg) {
+  ucg_int_t dx=0, dy=0;
+  uint8_t madctl_data=0;
+  uint8_t buff[2];
+
+  if ( ucg_clip_l90fx(ucg) == 0 )
+    return;
+
+  switch(ucg->arg.dir) {
+    case 0:
+      dx = 1;
+      dy = 0;
+      madctl_data = ST7789_MADCTL_COLUMN_ADDRESS_ORDER_RIGHT_TO_LEFT;
+      break;
+    case 1:
+      dx = 0;
+      dy = 1;
+      madctl_data = ST7789_MADCTL_PAGE_ADDRESS_ORDER_TOP_TO_BOTTOM;
+      break;
+    case 2:
+      dx = -1;
+      dy = 0;
+      madctl_data = ST7789_MADCTL_COLUMN_ADDRESS_ORDER_LEFT_TO_RIGHT;
+      break;
+    case 3:
+      dx = 0;
+      dy = -1;
+      madctl_data = ST7789_MADCTL_PAGE_ADDRESS_ORDER_BOTTOM_TO_TOP;
+      break;
+  }
+
+  ucg_com_SetCSLineStatus(ucg, 0);
+
+  send_cmd_data(ucg, ST7789_MADCTL, 1, &madctl_data);
+
+  set_column_address(
+    ucg,
+    ucg->arg.pixel.pos.x, // x_start
+    ucg->arg.pixel.pos.x + (ucg->arg.len * dx) // x_end
+  );
+  set_row_address(
+    ucg,
+    ucg->arg.pixel.pos.y, // y_start
+    ucg->arg.pixel.pos.y + (ucg->arg.len * dy) // y_end
+  );
+
+  send_cmd(ucg, ST7789_RAMWR);
+  ucg_com_SetCDLineStatus(ucg, (ucg->com_cfg_cd)&1);
+
+  set_16bit_color(ucg, buff);
+
+  for(ucg_int_t i = 0; i < ucg->arg.len; i++ ) {
+    ucg_com_SendString(ucg, 2, buff);
+    ucg->arg.pixel.pos.x+=dx;
+    ucg->arg.pixel.pos.y+=dy;
+  }
+
+  ucg_com_SetCSLineStatus(ucg, 1);
 }
 
 ucg_int_t ucg_dev_st7789_16x240x240(ucg_t *ucg, ucg_int_t msg, void *data) {
@@ -103,50 +219,28 @@ ucg_int_t ucg_dev_st7789_16x240x240(ucg_t *ucg, ucg_int_t msg, void *data) {
       return 1;
     case UCG_MSG_DRAW_PIXEL:
       if ( ucg_clip_is_pixel_visible(ucg) !=0 )  {
-        uint8_t r, g, b;
-        uint8_t buff[4];
-        uint16_t addr;
+        uint8_t buff[2];
 
         ucg_com_SetCSLineStatus(ucg, 0);
 
-         // Column addr set
-        addr = ucg->arg.pixel.pos.x;
-        buff[0] = (addr&0xFF00)>>8; // X start high bits
-        buff[1] = addr&0xFF; // X start low bits
-        buff[2] = buff[0]; // X end high bits
-        buff[3] = buff[1]; // X end low bits
-        send_cmd_data(ucg, ST7789_CASET, 4, buff);
-
-         // Row addr set
-        addr = ucg->arg.pixel.pos.y;
-        buff[0] = (addr&0xFF00)>>8; // X start high bits
-        buff[1] = addr&0xFF; // X start low bits
-        buff[2] = buff[0]; // X end high bits
-        buff[3] = buff[1]; // X end low bits
-        send_cmd_data(ucg, ST7789_RASET, 4, buff);
+        set_column_address(ucg, ucg->arg.pixel.pos.x, ucg->arg.pixel.pos.x);
+        set_row_address(ucg, ucg->arg.pixel.pos.y, ucg->arg.pixel.pos.y);
 
          // Write to RAM
-        // 16 bit: RRRRRGGG GGGBBBBB
-        buff[0] = 0;
-        buff[1] = 0;
-        r = ucg->arg.pixel.rgb.color[0]>>(8-5);
-        buff[0] |= r << 3;
-        g = ucg->arg.pixel.rgb.color[1]>>(8-6);
-        buff[0] |= g>>3;
-        buff[1] |= g<<5;
-        b = ucg->arg.pixel.rgb.color[2]>>(8-5);
-        buff[1] |= b&0x1F;
+        set_16bit_color(ucg, buff);
         send_cmd_data(ucg, ST7789_RAMWR, 2, buff);
 
         ucg_com_SetCSLineStatus(ucg, 1);
       }
       return 1;
     case UCG_MSG_DRAW_L90FX:
-      ucg_handle_l90fx(ucg, ucg_dev_st7789_16x240x240);
+      handle_l90fx(ucg);
+      return 1;
+    case UCG_MSG_DRAW_L90SE:
+      ucg_handle_l90se(ucg, ucg_dev_st7789_16x240x240);
       return 1;
   }
 
-  // UCG_MSG_DRAW_L90SE
   // UCG_MSG_SET_CLIP_BOX
   // UCG_MSG_SEND_BUFFER
   return ucg_dev_default_cb(ucg, msg, data);

--- a/csrc/ucg_dev_st7789.c
+++ b/csrc/ucg_dev_st7789.c
@@ -1,0 +1,153 @@
+#include "ucg.h"
+
+#define ST7789_SWRESET 0x01
+#define ST7789_SWRESET_DELAY_MS 5
+#define ST7789_SWRESET_DELAY_SLEEP_OUT_MS 120
+#define ST7789_SLPOUT 0x11
+#define ST7789_SLPOUT_DELAY_MS 5
+#define ST7789_SLPOUT_DELAY_SLEEP_IN_MS 120
+#define ST7789_COLMOD 0x3A
+#define ST7789_COLMOD_RGB_65K (1<<6|1<<4)  // 0x50
+#define ST7789_COLMOD_RGB_262K (1<<6|1<<5)  // 0x60
+#define ST7789_COLMOD_COLOR_12BIT (1<<1|1)  // 0x03
+#define ST7789_COLMOD_COLOR_16BIT (1<<2|1)  // 0x05
+#define ST7789_COLMOD_COLOR_16BIT_WRITE (ST7789_COLMOD_RGB_65K|ST7789_COLMOD_COLOR_16BIT)
+#define ST7789_COLMOD_COLOR_18BIT (1<<2|1<<1)  // 0x06
+#define ST7789_COLMOD_COLOR_READ (ST7789_COLMOD_RGB_262K|ST7789_COLMOD_COLOR_18BIT)
+#define ST7789_COLMOD_COLOR_16M (1<<2|1<<1|1)  // 0x07
+#define ST7789_MADCTL 0x36
+#define ST7789_CASET 0x2A
+#define ST7789_RASET 0x2B
+#define ST7789_INVOFF 0x20
+#define ST7789_INVON 0x21
+#define ST7789_DISPON 0x29
+#define ST7789_NORON 0x13
+#define ST7789_RAMWR 0x2C
+#define ST7789_MADCTL 0x36
+
+#define ST7789_RESX_TRW_MS 10 // Reset pulse duration 
+#define ST7789_RESX_TRT_MS 120 // Reset cancel
+
+static const ucg_pgm_uint8_t ucg_st7789_16x240x240_init_seq[] = {
+  UCG_CFG_CD(0,1),
+  UCG_RST(1),
+  UCG_CS(1),
+
+  // Hardware reset
+  UCG_RST(0),
+  UCG_DLY_MS(ST7789_RESX_TRW_MS),
+  UCG_RST(1),
+  UCG_DLY_MS(ST7789_RESX_TRT_MS),
+
+
+  // Software reset
+  UCG_CS(0),
+  UCG_C10(ST7789_SWRESET),
+  UCG_CS(1),
+  UCG_DLY_MS(ST7789_SWRESET_DELAY_MS),
+
+  UCG_CS(0),
+
+  // Out of sleep mode
+  UCG_C10(ST7789_SLPOUT),
+  UCG_DLY_MS(ST7789_SLPOUT_DELAY_SLEEP_IN_MS),
+
+  // Set color mode
+  UCG_C11(ST7789_COLMOD, ST7789_COLMOD_COLOR_16BIT_WRITE),
+
+  // Display inversion in practice works the opposite of what the datasheet
+  // says: on is off and off is on.
+  UCG_C10(ST7789_INVON),
+  // Datasheet states NORON should be the default after sw reset, but unless
+  // we explicitly set it, INVON will have no effect.
+  UCG_C10(ST7789_NORON),
+
+  // TODO clear RAM
+
+  // Main screen turn on
+  UCG_C10(ST7789_DISPON),
+
+  UCG_CS(1),
+
+  UCG_END(),
+};
+
+static void send_cmd(ucg_t *ucg, uint8_t cmd) {
+  ucg_com_SetCDLineStatus(ucg, (ucg->com_cfg_cd>>1)&1);
+  ucg_com_SendString(ucg, 1, &cmd);
+}
+
+static void send_data(ucg_t *ucg, uint16_t count, uint8_t *data) {
+  ucg_com_SetCDLineStatus(ucg, (ucg->com_cfg_cd)&1);
+  ucg_com_SendString(ucg, count, data);
+}
+
+static void send_cmd_data(ucg_t *ucg, uint8_t cmd, uint16_t count, uint8_t *data) {
+  send_cmd(ucg, cmd);
+  send_data(ucg, count, data);
+}
+
+ucg_int_t ucg_dev_st7789_16x240x240(ucg_t *ucg, ucg_int_t msg, void *data) {
+  switch(msg) {
+    case UCG_MSG_DEV_POWER_UP:
+      // Datasheet states 66ms for Serial clock cycle (Write) (~15MHz),
+      // But it seems to work fine at 20MHz...
+      ucg_com_PowerUp(ucg, 66, 0);
+      ucg_com_SendCmdSeq(ucg, ucg_st7789_16x240x240_init_seq);
+      return 1;
+    case UCG_MSG_DEV_POWER_DOWN:
+      return 1;
+    case UCG_MSG_GET_DIMENSION:
+      ((ucg_wh_t *)data)->w = 240;
+      ((ucg_wh_t *)data)->h = 240;
+      return 1;
+    case UCG_MSG_DRAW_PIXEL:
+      if ( ucg_clip_is_pixel_visible(ucg) !=0 )  {
+        uint8_t r, g, b;
+        uint8_t buff[4];
+        uint16_t addr;
+
+        ucg_com_SetCSLineStatus(ucg, 0);
+
+         // Column addr set
+        addr = ucg->arg.pixel.pos.x;
+        buff[0] = (addr&0xFF00)>>8; // X start high bits
+        buff[1] = addr&0xFF; // X start low bits
+        buff[2] = buff[0]; // X end high bits
+        buff[3] = buff[1]; // X end low bits
+        send_cmd_data(ucg, ST7789_CASET, 4, buff);
+
+         // Row addr set
+        addr = ucg->arg.pixel.pos.y;
+        buff[0] = (addr&0xFF00)>>8; // X start high bits
+        buff[1] = addr&0xFF; // X start low bits
+        buff[2] = buff[0]; // X end high bits
+        buff[3] = buff[1]; // X end low bits
+        send_cmd_data(ucg, ST7789_RASET, 4, buff);
+
+         // Write to RAM
+        // 16 bit: RRRRRGGG GGGBBBBB
+        buff[0] = 0;
+        buff[1] = 0;
+        r = ucg->arg.pixel.rgb.color[0]>>(8-5);
+        buff[0] |= r << 3;
+        g = ucg->arg.pixel.rgb.color[1]>>(8-6);
+        buff[0] |= g>>3;
+        buff[1] |= g<<5;
+        b = ucg->arg.pixel.rgb.color[2]>>(8-5);
+        buff[1] |= b&0x1F;
+        send_cmd_data(ucg, ST7789_RAMWR, 2, buff);
+
+        ucg_com_SetCSLineStatus(ucg, 1);
+      }
+      return 1;
+    case UCG_MSG_DRAW_L90FX:
+      ucg_handle_l90fx(ucg, ucg_dev_st7789_16x240x240);
+      return 1;
+  }
+
+  // UCG_MSG_DRAW_L90SE
+  // UCG_MSG_SET_CLIP_BOX
+  // UCG_MSG_SEND_BUFFER
+  return ucg_dev_default_cb(ucg, msg, data);
+}

--- a/csrc/ucg_dev_st7789.c
+++ b/csrc/ucg_dev_st7789.c
@@ -141,7 +141,6 @@ static void set_16bit_color(ucg_t *ucg, uint8_t buff[2]) {
   buff[1] |= b&0x1F;
 }
 
-#include <libopencm3/stm32/spi.h>
 
 static void handle_l90fx(ucg_t *ucg) {
   ucg_int_t dx=0, dy=0;

--- a/csrc/ucg_init.c
+++ b/csrc/ucg_init.c
@@ -42,6 +42,54 @@
 uint8_t global_SREG_backup;		// used by the atomic macros
 #endif
 
+static void default_power_up(ucg_t *ucg, ucg_com_info_t *ucg_com_info) {
+  ucg->com_cb(ucg, UCG_COM_MSG_POWER_UP, 0, (uint8_t *)ucg_com_info);
+}
+
+static void default_power_down(ucg_t *ucg) {
+  ucg->com_cb(ucg, UCG_COM_MSG_POWER_DOWN, 0, NULL);
+}
+
+static void default_delay(ucg_t *ucg, uint16_t microseconds) {
+  ucg->com_cb(ucg, UCG_COM_MSG_DELAY, microseconds, NULL);
+}
+
+static void default_change_reset_line(ucg_t *ucg, uint8_t state) {
+  ucg->com_cb(ucg, UCG_COM_MSG_CHANGE_RESET_LINE, state, NULL);
+}
+
+static void default_change_cd_line(ucg_t *ucg, uint8_t state) {
+  ucg->com_cb(ucg, UCG_COM_MSG_CHANGE_CD_LINE, state, NULL);
+}
+
+static void default_change_cs_line(ucg_t *ucg, uint8_t state) {
+  ucg->com_cb(ucg, UCG_COM_MSG_CHANGE_CS_LINE, state, NULL);
+}
+
+static void default_send_byte(ucg_t *ucg, uint8_t byte) {
+  ucg->com_cb(ucg, UCG_COM_MSG_SEND_BYTE, byte, NULL);
+}
+
+static void default_repeat_1_byte(ucg_t *ucg, uint16_t repeat, uint8_t byte) {
+  ucg->com_cb(ucg, UCG_COM_MSG_REPEAT_1_BYTE, repeat, &byte);
+}
+
+static void default_repeat_2_bytes(ucg_t *ucg, uint16_t repeat, uint8_t bytes[2]) {
+  ucg->com_cb(ucg, UCG_COM_MSG_REPEAT_2_BYTES, repeat, bytes);
+}
+
+static void default_repeat_3_bytes(ucg_t *ucg, uint16_t repeat, uint8_t bytes[3]) {
+  ucg->com_cb(ucg, UCG_COM_MSG_REPEAT_3_BYTES, repeat, bytes);
+}
+
+static void default_send_str(ucg_t *ucg, uint16_t length, uint8_t bytes[]) {
+  ucg->com_cb(ucg, UCG_COM_MSG_SEND_STR, length, bytes);
+}
+
+static void default_send_cd_data_sequence(ucg_t *ucg, uint16_t count, uint8_t bytes[]) {
+  ucg->com_cb(ucg, UCG_COM_MSG_SEND_CD_DATA_SEQUENCE, count, bytes);
+}
+
 static void ucg_init_struct(ucg_t *ucg);
 
 static void ucg_init_struct(ucg_t *ucg)
@@ -61,6 +109,19 @@ static void ucg_init_struct(ucg_t *ucg)
   ucg->com_initial_change_sent = 0;
   ucg->com_status = 0;
   ucg->com_cfg_cd = 0;
+
+  ucg->com_cb_funcs.power_up = default_power_up;
+  ucg->com_cb_funcs.power_down = default_power_down;
+  ucg->com_cb_funcs.delay = default_delay;
+  ucg->com_cb_funcs.change_reset_line = default_change_reset_line;
+  ucg->com_cb_funcs.change_cd_line = default_change_cd_line;
+  ucg->com_cb_funcs.change_cs_line = default_change_cs_line;
+  ucg->com_cb_funcs.send_byte = default_send_byte;
+  ucg->com_cb_funcs.repeat_1_byte = default_repeat_1_byte;
+  ucg->com_cb_funcs.repeat_2_bytes = default_repeat_2_bytes;
+  ucg->com_cb_funcs.repeat_3_bytes = default_repeat_3_bytes;
+  ucg->com_cb_funcs.send_str = default_send_str;
+  ucg->com_cb_funcs.send_cd_data_sequence = default_send_cd_data_sequence;
 }
 
 

--- a/csrc/ucg_init.c
+++ b/csrc/ucg_init.c
@@ -36,6 +36,7 @@
 
 #include "ucg.h"
 #include <string.h> 	/* memset */
+#include <stdlib.h>
 
 #ifdef __AVR__
 uint8_t global_SREG_backup;		// used by the atomic macros
@@ -52,6 +53,8 @@ static void ucg_init_struct(ucg_t *ucg)
   //ucg->display_offset.x = 0;
   //ucg->display_offset.y = 0;
   ucg->font = 0;
+  ucg->frame_buffer = NULL;
+  ucg->device_cb_real = NULL;
   //ucg->font_mode = UCG_FONT_MODE_NONE;   Old font procedures
   ucg->font_decode.is_transparent = 1;  // new font procedures
   
@@ -77,3 +80,16 @@ ucg_int_t ucg_Init(ucg_t *ucg, ucg_dev_fnptr device_cb, ucg_dev_fnptr ext_cb, uc
   return r;
 }
 
+ucg_int_t ucg_InitBuffer(ucg_t *ucg, ucg_dev_fnptr device_cb, ucg_dev_fnptr ext_cb, ucg_com_fnptr com_cb)
+{
+  ucg_int_t r;
+
+  r = ucg_Init(ucg, device_cb, ext_cb, com_cb);
+
+  ucg->frame_buffer = calloc(1, ucg_GetWidth(ucg) * ucg_GetHeight(ucg) * 3);
+
+  ucg->device_cb_real = ucg->device_cb;
+  ucg->device_cb = ucg_dev_buffer;
+
+  return r;
+}


### PR DESCRIPTION
Implements an optional frame buffer on top of existing functionality. It works by redirecting all drawing functions to happen in memory, and allow users to explicitly send the buffer as a whole to the display when finished. This eliminates all visual artifacts resulting from updating graphics directly on the display memory.

Given that not all use cases have enough memory for a frame buffer, users can optionally use it with:

```c
  ucg_InitBuffer(
    &ucg,
    ucg_dev_ssd1351_18x128x128_ilsoft,
    ucg_ext_ssd1351_18,
    ucg_com_cm3_4wire_HW_SPI
  );
  ucg_SetColor(&ucg, 0, 255, 255, 255);
  ucg_DrawBox(&ucg, 0, 0, 100, 10);
  ucg_SendBuffer(&ucg);
```
Data will be all pumped to the display only when `ucg_SendBuffer` is called.

I tested this with a SSD1351 and the SDL examples, everything seems all right.

Implementation details:

- `ucg_InitBuffer` puts a new `ucg_dev_buffer` in place of `ucg->device_cb`.
- `ucg_dev_buffer` catches all drawing calls and draws them them in memory.
- `ucg_SendBuffer` temporarily puts the original device callback and invokes it with the new `UCG_MSG_SEND_BUFFER` command.
- `UCG_MSG_SEND_BUFFER` has a default implementation at `ucg_dev_default_cb.c` which all displays can use.
- Because this is not fast, each display driver can / should have its own optimized implementation.
- I added `UCG_MSG_SEND_BUFFER` to `ucg_dev_ic_ssd1351.c`, which is able to send the buffer at bus speed.
- Similar few lines implementation for other displays should be easy, however I don't have them at hand to test any changes.

Closes #122.

PS: This PR is on top of #123, which should be reviewed / merged first.