### PR TITLE
Add support for a pointer to user data.

### DIFF
--- a/cppsrc/Ucglib.h
+++ b/cppsrc/Ucglib.h
@@ -89,6 +89,10 @@ class Ucglib : public Print
     ucg_int_t getWidth(void) { return ucg_GetWidth(&ucg); }
     ucg_int_t getHeight(void) { return ucg_GetHeight(&ucg); }
     
+#ifdef WITH_USER_PTR
+    void *getUserPtr() { return ucg_GetUserPtr(&ucg); }
+    void setUserPtr(void *p) { ucg_SetUserPtr(&ucg, p); }
+#endif
     
     void setFontRefHeightText(void) 	{ ucg_SetFontRefHeightText(&ucg); }
     void setFontRefHeightExtendedText(void) { ucg_SetFontRefHeightExtendedText(&ucg); }

--- a/csrc/ucg.h
+++ b/csrc/ucg.h
@@ -96,6 +96,9 @@ extern "C"
 #endif
 #endif
 
+/* Define this for an additional user pointer inside the ucg data struct */
+//#define WITH_USER_PTR
+
 #ifdef __GNUC__
 #  define UCG_NOINLINE __attribute__((noinline))
 #  define UCG_SECTION(name) __attribute__ ((section (name)))
@@ -411,6 +414,10 @@ struct _ucg_t
   int8_t font_ref_ascent;
   int8_t font_ref_descent;
 
+#ifdef WITH_USER_PTR
+  void *user_ptr;
+#endif
+
   /* only for Arduino/C++ Interface */
 #ifdef USE_PIN_LIST
   uint8_t pin_list[UCG_PIN_COUNT];
@@ -421,6 +428,8 @@ struct _ucg_t
 #endif
 
 #endif
+
+
 
   /* 
     Small amount of RAM for the com interface (com_cb).
@@ -436,6 +445,11 @@ struct _ucg_t
 
 #define ucg_GetWidth(ucg) ((ucg)->dimension.w)
 #define ucg_GetHeight(ucg) ((ucg)->dimension.h)
+
+#ifdef WITH_USER_PTR
+#define ucg_GetUserPtr(ucg) ((ucg)->user_ptr)
+#define ucg_SetUserPtr(ucg, p) ((ucg)->user_ptr = (p))
+#endif
 
 #define UCG_MSG_DEV_POWER_UP	10
 #define UCG_MSG_DEV_POWER_DOWN 11


### PR DESCRIPTION
This PR adds `ucg_GetUserPtr` and `ucg_SetUserPtr` to store user data. This feature is disabled by default, and can be enabled by adding `WITH_USER_PTR`.

If enabled, the `ucg_t` structure is extended with an additional `void* user_ptr`.

This feature is copy/pasted from the U8g2 library ([commit](https://github.com/olikraus/u8g2/commit/a679f167f6d3747ce34ccc1ff5fecec3a38b929f)). I'm using this for the RIOT-OS port of Ucglib.