### PR TITLE
Fixed "__NOP not defined" on STM32 boards

### DIFF
--- a/cppsrc/Ucglib.cpp
+++ b/cppsrc/Ucglib.cpp
@@ -40,6 +40,13 @@
 
 #include "Ucglib.h"
 
+#if defined(__arm__)
+#if defined(__NOP)
+#undef __NOP
+#endif
+#define __NOP __asm volatile ("nop")
+#endif
+
 /*=========================================================================*/
 /* 8 Bit SW SPI */
 


### PR DESCRIPTION
Added __NOP define, for STM32 boards using the stm32duino library